### PR TITLE
[NOD-530] feat: Semantic versioning, new GH Action add_patch_label

### DIFF
--- a/.github/workflows/01_add_patch_label.yml
+++ b/.github/workflows/01_add_patch_label.yml
@@ -1,0 +1,60 @@
+name: Add PATCH default label
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request_target:
+    branches:
+      - main
+    types: [ opened, reopened ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  add_patch_label:
+    runs-on: ubuntu-latest
+    name: Add default label
+    steps:
+      - name: Check user labels
+        id: check_user_labels
+        uses: actions/github-script@v6.3.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var addPatch = "true";
+            // retrieve label list
+            let labels = await github.rest.issues.listLabelsOnIssue({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+            });
+            
+            // verify if user have already added IGNORE-FOR-RELEASE, then skip add PATCH
+            // note: GitHub labels are added in .identity/03_github_environment.tf as github_issue_label resource
+            if (labels.data.find(label => label.name === 'ignore-for-release')){
+              addPatch = "false";
+            }
+            return addPatch;
+          result-encoding: string
+
+      - name: Add PATCH label
+        if: ${{ steps.check_user_labels.outputs.result == 'true' }}
+        uses: pagopa/github-actions-template/default-label@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          label: 'patch'
+
+      - name: Add comment
+        if: ${{ steps.check_user_labels.outputs.result == 'true' }}
+        uses: actions/github-script@v6.3.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'The default action is to increase the `PATCH` number of `SEMVER`. Set `IGNORE-FOR-RELEASE` if you want to skip `SEMVER` bump. `BREAKING-CHANGE` and `NEW-RELEASE` must be run from GH Actions section manually.'
+              });

--- a/.github/workflows/03_code_review.yml
+++ b/.github/workflows/03_code_review.yml
@@ -38,4 +38,4 @@ jobs:
           coverage_exclusions: "**/config/*,**/*Mock*,**/models/**,**/entities/*"
           cpd_exclusions: "**/models/**,**/entities/*"
           java_distribution: "graalvm"
-          java_version: '17'
+          java_version: "17.0.7"

--- a/.github/workflows/03_code_review.yml
+++ b/.github/workflows/03_code_review.yml
@@ -30,7 +30,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Code Review
-        uses: pagopa/github-actions-template/maven-code-review@50aaf5cffa09d76b953e64a630bc9e0528a6d73b
+        uses: pagopa/github-actions-template/maven-code-review@v1.8.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
@@ -38,4 +38,4 @@ jobs:
           coverage_exclusions: "**/config/*,**/*Mock*,**/models/**,**/entities/*"
           cpd_exclusions: "**/models/**,**/entities/*"
           java_distribution: "graalvm"
-          java_version: "17.0.7"
+          java_version: '17'

--- a/.github/workflows/04_release_deploy.yml
+++ b/.github/workflows/04_release_deploy.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Semver setup
         id: semver_setup
-        uses: pagopa/github-actions-template/nodo5-semver-setup@de4ca1ddefb1461c176cc42259e494158b578fe3
+        uses: pagopa/github-actions-template/nodo5-semver-setup@ce252c8501c9242bd6045f7cdd650736b2f38777
         with:
           semver: ${{ inputs.semver }}
 


### PR DESCRIPTION
### [NOD-530] feat: Semantic versioning, new GH Action add_patch_label

This PR is crucial for updating the repositories on GitHub Actions to utilize the new management of semantic versioning effectively.

#### List of Changes
- GH Action Version Update: The version of the GH Action setup for semantic versioning has been updated: nodo5-semver-setup@[SHA].

- New GH Action Addition: The new GH Action add_patch_label.yml has been added.

#### Motivation and Context

This PR aims to keep the GitHub Actions updated and to improve the semantic versioning processing.

#### How Has This Been Tested?

The changes have been tested by running the pipeline.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[NOD-530]: https://pagopa.atlassian.net/browse/NOD-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ